### PR TITLE
Upgrade to 0.12 and some intial support for future VPC support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 
 # .tfvars files
 *.tfvars
+*.idea/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ The following resources are supported:
 * aws_transfer_user
 * aws_transfer_ssh_key
 
-This Module will optionally create a Route53 CNAME Record for the server endpoint.
+This Module will optionally create a Route53 CNAME Record for the server endpoint & also the IAM logging role. There's also some ability to create an internet facing Transfer service using the VPC.
+Terraform doesn't currently support this functionality, but this current PR is open [Terraform PR]("https://github.com/terraform-providers/terraform-provider-aws/pull/11751)
 
 
 ## Usage
@@ -49,7 +50,7 @@ module "transfer_user_key_bodys" {
 
 ## Terraform Versions
 This module supports Terraform v0.11 from v0.0.1
-Terraform v0.12 support is coming soon...
+This module supports Terraform v0.12
 
 ## Authors
 Module managed by  

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,24 @@
+data "aws_iam_policy_document" "trust_policy" {
+  statement {
+    effect = "Allow"
+    principals {
+      identifiers = ["transfer.amazonaws.com"]
+      type        = "Service"
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+data "aws_iam_policy_document" "logging" {
+  statement {
+    sid    = "SFTPLoggingTrust"
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:DescribeLogStreams",
+      "logs:CreateLogGroup",
+      "logs:PutLogEvents",
+    ]
+    resources = ["*"]
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,20 +1,47 @@
 resource "aws_transfer_server" "this" {
-  count = "${var.create_transfer_server? 1 : 0}"
+  count = var.create_transfer_server ? 1 : 0
 
-  identity_provider_type = "${var.identity_provider_type}"
-  logging_role           = "${var.logging_role_arn}"
+  identity_provider_type = var.identity_provider_type
+  logging_role           = var.logging_role_arn
 
-  endpoint_type = "${var.endpoint_type}"
+  endpoint_type = var.endpoint_type
 
-  tags = "${var.tags}"
+  tags = var.tags
 }
 
 resource "aws_route53_record" "this" {
-  provider = "aws.dns"
-  count   = "${var.create_route53_record ? 1 : 0}"
-  name    = "${var.route53_record_name}"
+  provider = aws.dns
+  count    = var.create_route53_record ? 1 : 0
+
+  name    = var.route53_record_name
   type    = "CNAME"
-  zone_id = "${var.route53_record_zone}"
-  records = ["${element(concat(aws_transfer_server.this.*.endpoint, list("")), 0)}"]
+  zone_id = var.route53_record_zone
+  records = [concat(aws_transfer_server.this[*].endpoint, var.transfer_server_endpoint_name)[0]]
   ttl     = 3600
+}
+
+resource "aws_iam_role" "logging" {
+  count = var.create_transfer_logging_role ? 1 : 0
+
+  name = var.logging_role_name
+  path = var.iam_path
+
+  assume_role_policy    = data.aws_iam_policy_document.trust_policy.json
+  force_detach_policies = true
+
+  // Maybe Merge some IAM specific Tags.
+  tags = var.tags
+}
+
+resource "aws_iam_policy" "logging" {
+  count = var.create_transfer_logging_role ? 1 : 0
+
+  name   = var.logging_policy_name
+  path   = var.iam_path
+  policy = data.aws_iam_policy_document.logging.json
+}
+
+resource "aws_eip" "this" {
+  count = var.internet_facing_eip ? var.internet_facing_eip_count : 0
+  tags  = var.tags
 }

--- a/modules/transfer-user/data.tf
+++ b/modules/transfer-user/data.tf
@@ -1,6 +1,6 @@
 data "aws_iam_policy_document" "trust_policy" {
   statement {
-    effect  = "Allow"
+    effect = "Allow"
     principals {
       identifiers = ["transfer.amazonaws.com"]
       type        = "Service"
@@ -10,12 +10,13 @@ data "aws_iam_policy_document" "trust_policy" {
 }
 
 data "aws_iam_policy_document" "inline_policy" {
-  count         = "${var.create_iam_role? 1 : 0}"
-  override_json = "${var.iam_role_policy_statements}"
+  count         = var.create_iam_role ? 1 : 0
+  override_json = var.iam_role_policy_statements
 }
 
 data "aws_ssm_parameter" "user_ssh_key" {
-  count           = "${var.use_ssm? length(var.transfer_ssh_key_ssm_paths) : 0}"
-  name            = "${element(var.transfer_ssh_key_ssm_paths,count.index)}"
+  count           = var.use_ssm ? length(var.transfer_ssh_key_ssm_paths) : 0
+  name            = element(var.transfer_ssh_key_ssm_paths, count.index)
   with_decryption = true
 }
+

--- a/modules/transfer-user/main.tf
+++ b/modules/transfer-user/main.tf
@@ -1,30 +1,34 @@
 locals {
-  all_key_bodies = "${concat(var.transfer_ssh_key_bodys, data.aws_ssm_parameter.user_ssh_key.*.value)}"
+  all_key_bodies = concat(
+    var.transfer_ssh_key_bodys,
+    data.aws_ssm_parameter.user_ssh_key.*.value,
+  )
 }
 
 resource "aws_transfer_user" "this" {
-  role           = "${var.create_iam_role? element(concat(aws_iam_role.this.*.arn,list("")),0) : var.iam_role_arn}"
-  server_id      = "${var.transfer_server_id}"
-  user_name      = "${var.user_name}"
-  tags           = "${var.tags}"
-  home_directory = "${var.home_directory}"
+  role           = var.create_iam_role ? element(concat(aws_iam_role.this.*.arn, [""]), 0) : var.iam_role_arn
+  server_id      = var.transfer_server_id
+  user_name      = var.user_name
+  tags           = var.tags
+  home_directory = var.home_directory
 }
 
 resource "aws_transfer_ssh_key" "ssh_key" {
-  count     = "${var.add_transfer_ssh_keys ? length(local.all_key_bodies) : 0}"
-  body      = "${element(concat(local.all_key_bodies,list("")),count.index)}"
-  server_id = "${var.transfer_server_id}"
-  user_name = "${aws_transfer_user.this.user_name}"
+  count     = var.add_transfer_ssh_keys ? length(local.all_key_bodies) : 0
+  body      = element(concat(local.all_key_bodies, [""]), count.index)
+  server_id = var.transfer_server_id
+  user_name = aws_transfer_user.this.user_name
 }
 
 resource "aws_iam_role" "this" {
-  count              = "${var.create_iam_role? 1 : 0}"
-  assume_role_policy = "${data.aws_iam_policy_document.trust_policy.json}"
+  count              = var.create_iam_role ? 1 : 0
+  assume_role_policy = data.aws_iam_policy_document.trust_policy.json
   name               = "Transfer-user-${var.user_name}"
 }
 
 resource "aws_iam_role_policy" "inline_policy" {
-  count  = "${var.create_iam_role? 1 : 0}"
-  policy = "${data.aws_iam_policy_document.inline_policy.json}"
-  role   = "${aws_iam_role.this.id}"
+  count  = var.create_iam_role ? 1 : 0
+  policy = data.aws_iam_policy_document.inline_policy[0].json
+  role   = aws_iam_role.this[0].id
 }
+

--- a/modules/transfer-user/variables.tf
+++ b/modules/transfer-user/variables.tf
@@ -24,7 +24,7 @@ variable "iam_role_arn" {
 variable "tags" {
   description = "Tags to attach to transfer user"
   default     = {}
-  type        = "map"
+  type        = map(string)
 }
 
 variable "home_directory" {
@@ -40,7 +40,7 @@ variable "add_transfer_ssh_keys" {
 variable "transfer_ssh_key_bodys" {
   description = "Public key part of SSH Key for Transfer user being created."
   default     = []
-  type        = "list"
+  type        = list(string)
 }
 
 variable "use_ssm" {
@@ -50,6 +50,7 @@ variable "use_ssm" {
 
 variable "transfer_ssh_key_ssm_paths" {
   description = "List of SSM Parameter store paths to retrieve public key from."
-  type        = "list"
+  type        = list(string)
   default     = ["/transfer/users/user"]
 }
+

--- a/modules/transfer-user/versions.tf
+++ b/modules/transfer-user/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,11 @@
 output "r53_record_fqdn" {
-  value = "${element(concat(aws_route53_record.this.*.fqdn, list("")),0)}"
+  value = element(concat(aws_route53_record.this.*.fqdn, [""]), 0)
 }
 
 output "transfer_server_endpoint" {
-  value = "${element(concat(aws_transfer_server.this.*.endpoint,list("")),0)}"
+  value = element(concat(aws_transfer_server.this.*.endpoint, [""]), 0)
 }
 
 output "transfer_server_id" {
-  value = "${element(concat(aws_transfer_server.this.*.id,list("")),0)}"
+  value = element(concat(aws_transfer_server.this.*.id, [""]), 0)
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,4 +1,7 @@
-provider "aws" {}
 provider "aws" {
-  alias = "dns"
+  region = var.aws_region
+  alias  = "dns"
+  assume_role {
+    role_arn = var.dns_role_arn
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,31 +1,87 @@
 variable "create_transfer_server" {
-  default = true
+  description = "Create the Transfer Server"
+  default     = true
+}
+
+variable "create_transfer_logging_role" {
+  description = "Create the IAM Role for logging"
+  default     = true
+}
+
+variable "logging_role_name" {
+  description = "Name of logging role to if creating one"
+  default     = "default-transfer-server-role"
+}
+
+variable "logging_policy_name" {
+  description = "Name of logging policy to create"
+  default     = "default-transfer-server-policys"
 }
 
 variable "logging_role_arn" {
+  description = "Arn of role to use to allow the service to log"
+  default     = ""
 }
 
 variable "identity_provider_type" {
-  default = "SERVICE_MANAGED"
+  description = "Type of identitiy provider used within the transfer service"
+  default     = "SERVICE_MANAGED"
 }
 
 variable "tags" {
-  type    = "map"
-  default = {}
+  description = "Tags to apply to resource"
+  type        = map(string)
+  default     = {}
 }
 
 variable "endpoint_type" {
-  default = "PUBLIC"
+  description = "The endpoint type for the transfer server"
+  default     = "PUBLIC"
+}
+
+variable "internet_facing_eip" {
+  description = "If your using a Internet Facing VPC Endpoint type creates EIPS"
+  default     = false
+}
+
+variable "internet_facing_eip_count" {
+  description = "Number of EIPs you wish to create"
+  default     = 0
 }
 
 variable "create_route53_record" {
   description = "Whether to create the Route53 Record."
-  default = false
+  default     = false
 }
 
 variable "route53_record_name" {
-  default = ""
+  description = "Route53 Record Name"
+  default     = ""
 }
+
 variable "route53_record_zone" {
-  default = ""
+  description = "Route53 Zone ID"
+  default     = ""
+}
+
+variable "transfer_server_endpoint_name" {
+  description = "Option to create a R53 Record, added due to transfer server lacking VPC functionality"
+  default     = []
+
+  type = list(string)
+}
+
+variable "dns_role_arn" {
+  description = "Route53 DNS role arn if applicable"
+  default     = ""
+}
+
+variable "iam_path" {
+  description = "IAM Path applied to IAM role"
+  default     = ""
+}
+
+variable "aws_region" {
+  description = "AWS region used in provider"
+  default     = "eu-west-1"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
I've added support for EIPs which when support is added within terraform you should then be able to associate EIPs with a transfer server.