### PR TITLE
feat: transfer-server-enhancements

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,9 +2,19 @@ resource "aws_transfer_server" "this" {
   count = var.create_transfer_server ? 1 : 0
 
   identity_provider_type = var.identity_provider_type
-  logging_role           = var.logging_role_arn
-
-  endpoint_type = var.endpoint_type
+  logging_role           = var.create_transfer_logging_role == true ? aws_iam_role.logging[0].arn : var.logging_role_arn
+  endpoint_type          = var.endpoint_type
+  protocols              = var.protocols
+  certificate            = var.certificate
+  function               = var.function
+  url                    = var.url
+  invocation_role        = var.invocation_role
+  endpoint_details {
+    subnet_ids             = var.subnet_ids
+    vpc_id                 = var.vpc_id
+    security_group_ids     = var.security_group_ids
+    address_allocation_ids = var.address_allocation_ids
+  }
 
   tags = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -85,3 +85,57 @@ variable "aws_region" {
   description = "AWS region used in provider"
   default     = "eu-west-1"
 }
+
+variable "protocols" {
+  description = "Specifies the file transfer protocol or protocols over which your file transfer protocol client can connect to your server's endpoint"
+  default     = ["SFTP"]
+  type        = list(string)
+}
+
+variable "certificate" {
+  description = "The Amazon Resource Name (ARN) of the AWS Certificate Manager (ACM) certificate"
+  default     = ""
+}
+
+variable "function" {
+  description = "The ARN for a lambda function to use for the Identity provider"
+  default     = ""
+}
+
+variable "url" {
+  description = "URL of the service endpoint used to authenticate users with an identity_provider_type of API_GATEWAY"
+  default = ""
+}
+
+variable "invocation_role" {
+  description = "Amazon Resource Name (ARN) of the IAM role used to authenticate the user account with an identity_provider_type of API_GATEWAY"
+  default = ""
+}
+
+variable "address_allocation_ids" {
+  description = "A list of address allocation IDs that are required to attach an Elastic IP address to your SFTP server's endpoint. This property can only be used when endpoint_type is set to VPC"
+  default     = []
+  type = list(string)
+}
+
+variable "security_group_ids" {
+  description = "A list of security groups IDs that are available to attach to your server's endpoint. If no security groups are specified, the VPC's default security groups are automatically assigned to your endpoint. This property can only be used when endpoint_type is set to VPC."
+  default     = []
+  type = list(string)
+}
+
+variable "subnet_ids" {
+  description = "A list of subnet IDs that are required to host your SFTP server endpoint in your VPC. This property can only be used when endpoint_type is set to VPC"
+  default     = []
+  type = list(string)
+}
+
+variable "vpc_endpoint_id" {
+  description = "The ID of the VPC endpoint. This property can only be used when endpoint_type is set to VPC_ENDPOINT"
+  default = ""
+}
+
+variable "vpc_id" {
+  description = "The VPC ID of the virtual private cloud in which the SFTP server's endpoint will be hosted. This property can only be used when endpoint_type is set to VPC."
+  default = ""
+}


### PR DESCRIPTION
Additional vars to allow more deployment options, will now allow identity provider type = API_GATEWAY