### PR TITLE
fix: Removing providers file that shouldn't really be in here.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,8 +39,7 @@ resource "aws_iam_role" "logging" {
   assume_role_policy    = data.aws_iam_policy_document.trust_policy.json
   force_detach_policies = true
 
-  // Maybe Merge some IAM specific Tags.
-  tags = var.tags
+  tags = merge(var.tags, { Name = var.logging_role_name, Role = "${var.logging_role_name} iam role" })
 }
 
 resource "aws_iam_policy" "logging" {
@@ -49,6 +48,8 @@ resource "aws_iam_policy" "logging" {
   name   = var.logging_policy_name
   path   = var.iam_path
   policy = data.aws_iam_policy_document.logging.json
+
+  tags = merge(var.tags, { Name = var.logging_policy_name, Role = var.logging_policy_name })
 }
 
 resource "aws_eip" "this" {

--- a/modules/custom_identity_provider/variables.tf
+++ b/modules/custom_identity_provider/variables.tf
@@ -27,3 +27,27 @@ variable "tags" {
   default     = {}
   type        = map(string)
 }
+
+variable "transfer_iam_role_name" {
+  description = "Transfer server IAM role name"
+  default     = "TransferCustomIdentityProviderRole"
+  type        = string
+}
+
+variable "lambda_iam_role_name" {
+  description = "Lambda IAM role name"
+  default     = "TransferCustomIdentityProviderLambdaRole"
+  type        = string
+}
+
+variable "api_gateway_rest_api_name" {
+  default     = "Transfer Custom Identity Provider"
+  description = "Name of the REST API"
+  type        = string
+}
+
+variable "api_gateway_stage_name" {
+  default     = "prod"
+  description = "Name of the stage"
+  type        = string
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,7 +1,0 @@
-provider "aws" {
-  region = var.aws_region
-  alias  = "dns"
-  assume_role {
-    role_arn = var.dns_role_arn
-  }
-}


### PR DESCRIPTION
This can cause issues with some uses of this module. Providers shouldn't be checked in, they will be inherited from the parent terraform level.

