### PR TITLE
fix: use absolute path to lambda.zip

### DIFF
--- a/modules/custom_identity_provider/main.tf
+++ b/modules/custom_identity_provider/main.tf
@@ -51,8 +51,8 @@ resource "aws_lambda_function" "this_lambda" {
   runtime          = "python3.9"
   description      = "A function to lookup and return user data from AWS Secrets Manager."
   tags             = var.tags
-  filename         = "lib/lambda.zip"
-  source_code_hash = filebase64sha256("lib/lambda.zip")
+  filename         = "${path.module}/lib/lambda.zip"
+  source_code_hash = filebase64sha256("${path.module}/lib/lambda.zip")
 
   environment {
     variables = {


### PR DESCRIPTION
filebase64sha256 is unable to find "lib/lambda.zip" when using this module from another module because the relative path doesn't resolve to the right place in that context.

This changes both references to lambda.zip to use the absolute path by prefixing it with `path.module`.