### PR TITLE
Allows variable name for identity provider lookup lambda

### DIFF
--- a/modules/custom_identity_provider/main.tf
+++ b/modules/custom_identity_provider/main.tf
@@ -45,7 +45,7 @@ resource "aws_iam_role_policy_attachment" "policy" {
 # Lambda Deployment
 #
 resource "aws_lambda_function" "this_lambda" {
-  function_name    = "TransferCustomIdentityProviderCredentialLookup"
+  function_name    = var.identity_provider_lookup_lambda_name
   handler          = "lambda.lambda_handler"
   role             = coalesce(concat(aws_iam_role.this_lambda.*.arn, [])[0], var.lambda_role_arn)
   runtime          = "python3.9"

--- a/modules/custom_identity_provider/variables.tf
+++ b/modules/custom_identity_provider/variables.tf
@@ -51,3 +51,9 @@ variable "api_gateway_stage_name" {
   description = "Name of the stage"
   type        = string
 }
+
+variable "identity_provider_lookup_lambda_name" {
+  default     = "TransferCustomIdentityProviderCredentialLookup"
+  description = "The name of the AWS Lambda function used to lookup user details from the custom identity provider. Must be unique."
+  type        = string
+}


### PR DESCRIPTION
I added a variable to allow a different name for the lambda used to lookup user details from the custom identity provider. This is necessary to have multple instantiations of the "customer identity provider"